### PR TITLE
Fix import and stuck connection issues + add get_nodes function

### DIFF
--- a/gevent_dht/finger.py
+++ b/gevent_dht/finger.py
@@ -64,6 +64,17 @@ class FingerTable():
             if len(self.table[i]) < self.min_count:
                 yield int(i)
                 
+    def get_nodes(self):
+        """
+        return a list of nodes in the finger table so far
+        """
+        nodes = []
+        for i in range(len(self.table)):
+            for node in self.table[i]:
+                host = """%s:%d""" % (node.host, node.port)
+                nodes.append(host)
+        return nodes
+        
     def get_node_from_level(self, level, uid):
         """
         Gets the node which is a certain level away from another uid

--- a/gevent_dht/network.py
+++ b/gevent_dht/network.py
@@ -1,3 +1,7 @@
+import sys
+if 'threading' in sys.modules:
+    del sys.modules['threading']
+
 import gevent.monkey
 gevent.monkey.patch_all()
 

--- a/gevent_dht/protocol.py
+++ b/gevent_dht/protocol.py
@@ -51,6 +51,10 @@ class Protocol():
         msg = ''
         while True:
             new_data = conn.recv(32)
+            if new_data == '': # If connection failed, close it
+                self.finger.remove(self.Node)
+                self.remote_conn.close()
+                break
             msg += new_data
             if '|' in msg:
                 length, remainder = msg.split('|', 1)


### PR DESCRIPTION
Hello,

While using the module you developed, we made a few changes to fix some runtime issues we were having, so we are contributing it to your repository as we think that this would benefit everyone:
- KeyError exception while importing threading module : Monkey patching the threading module with gevent after importing it raised an exception, so we just "un-imported" it before the monkey patching (http://stackoverflow.com/a/18455952).
- If the connection is broken from another node, the current node might infinitely wait for a response when it won't get any. If no response is received, we just get out of the infinite loop after closing the connection with that node.

We also added the ability to get the list of all nodes in the network based on @hoangelos 's implementation: https://github.com/hoangelos/gevent-dht/commit/8ce9d7d3ed98b18aa84162439d66208bb6bd9fa4

Thanks,

Adrien Kaiser
Lyon, France
